### PR TITLE
flake: don't add substituter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -97,7 +97,4 @@
     pypuv.inputs.nixpkgs.follows = "nixpkgs";
     pypuv.inputs.pyproject-nix.follows = "pyp";
   };
-
-  nixConfig.extra-substituters = [ "https://cache.ysun.co" ];
-  nixConfig.extra-trusted-public-keys = [ "cache.ysun.co-1:WxPYwT5g3kt9XhUhHPpNLZKI9HIOsVVAuqSHpok8Qt4=" ];
 }


### PR DESCRIPTION
Substituters should only be used where strictly necessary due to their security risks. Before this commit, an undocumented 3rd party cache was prioritized over the official one in GitHub Actions runs.