### PR TITLE
workflows: pin to full git SHAs

### DIFF
--- a/.github/actions/atelier/action.yaml
+++ b/.github/actions/atelier/action.yaml
@@ -20,7 +20,7 @@ runs:
   steps:
     - name: Reclaim Disk Space (Linux)
       if: ${{ inputs.reclaim == 'true' && runner.os == 'Linux' }}
-      uses: wimpysworld/nothing-but-nix@main
+      uses: wimpysworld/nothing-but-nix@687c797a730352432950c707ab493fcc951818d7 # v10
       with:
         hatchet-protocol: rampage
 
@@ -81,7 +81,7 @@ runs:
 
     - name: Install Nix
       if: ${{ inputs.install-command == '' }}
-      uses: nixos/nix-installer-action@main
+      uses: nixos/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # 2026-04-06
       with:
         # authenticate github api calls so flake fetches (github: refs, the
         # nixpkgs registry, the niks3 install) get the 5000/hr token limit
@@ -138,7 +138,7 @@ runs:
 
     - name: Report Disk Space (Darwin)
       if: ${{ inputs.reclaim == 'true' && runner.os == 'macOS' }}
-      uses: srz-zumix/post-run-action@v3
+      uses: srz-zumix/post-run-action@42756f7452b9439d0365b7e087b2c364f54209c6 # v3.0.2
       with:
         shell: bash -e {0}
         post-run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,7 +57,7 @@ jobs:
       EVAL_ERROR: ${{ matrix.error }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
@@ -186,7 +186,7 @@ jobs:
 
       - name: Upload Log
         if: ${{ always() && matrix.installable != '' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           # the label is the flake attribute, unique per cell across all chunks
           # strategy.job-index resets per chunk so it would collide otherwise

--- a/.github/workflows/discover.yaml
+++ b/.github/workflows/discover.yaml
@@ -117,7 +117,7 @@ jobs:
       skipped: ${{ steps.gen.outputs.skipped }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Tags are not sufficient to pin an action. What they reference can be later changed. This supply chain attack has wreaked havoc multiple times recently.

This commit also provides a solution to usining the correct repo in forks.
In the future the proposed `$/` syntax may improve this. See <https://github.com/orgs/community/discussions/26245#discussioncomment-15601440>.

I think it would also be good to update the documentation, so that people can benefit from pinning atelier itself.
Another observation is that currently the recommendation is for users to use `@master`. Besides security concerns, this doesn't allow for breaking changes to be made to atelier. 