### PR TITLE
workflows: make tool follow workflow pin by default

### DIFF
--- a/.github/workflows/discover.yaml
+++ b/.github/workflows/discover.yaml
@@ -12,11 +12,11 @@ on:
       repository:
         description: Atelier repository
         type: string
-        default: stepbrobd/atelier
+        default: ""
       ref:
         description: Atelier repository Git ref
         type: string
-        default: master
+        default: ""
       rules:
         description: Rule file path
         type: string
@@ -126,7 +126,12 @@ jobs:
           RULES: ${{ inputs.rules }}
           ATTR: ${{ inputs.attr }}
           TOOL: ${{ inputs.tool }}
-          TOOL_DEFAULT: github:${{ inputs.repository }}/${{ inputs.ref }}
+          REPOSITORY: ${{ inputs.repository }}
+          REF: ${{ inputs.ref }}
+          REPOSITORY_DEFAULT: stepbrobd/atelier
+          REF_DEFAULT: master
+          WORKFLOW_REPOSITORY: ${{ job.workflow_repository }}
+          WORKFLOW_SHA: ${{ job.workflow_sha }}
           # nix-eval-jobs uses up to ~4 GiB per worker, so the aggregate
           # (workers x 4 GiB) must fit the runner; a low count keeps heavy
           # config toplevel evals from OOM-killing the whole runner
@@ -136,6 +141,19 @@ jobs:
           ON_AARCH64_DARWIN: ${{ inputs.aarch64-darwin }}
         run: |
           set -euo pipefail
+
+          resolve_tool() {
+            if [ -n "$TOOL" ]; then
+              printf '%s\n' "$TOOL"
+            elif [ -n "$REPOSITORY" ] || [ -n "$REF" ]; then
+              printf 'github:%s/%s\n' \
+                "${REPOSITORY:-$REPOSITORY_DEFAULT}" \
+                "${REF:-$REF_DEFAULT}"
+            else
+              printf 'github:%s/%s\n' "$WORKFLOW_REPOSITORY" "$WORKFLOW_SHA"
+            fi
+          }
+ 
           systems=""
           [ "${ON_X8664_LINUX:-true}" != "false" ] && systems="${systems:+$systems,}x86_64-linux"
           [ "${ON_AARCH64_LINUX:-true}" != "false" ] && systems="${systems:+$systems,}aarch64-linux"
@@ -150,7 +168,7 @@ jobs:
             exit 0
           fi
 
-          nix run "${TOOL:-$TOOL_DEFAULT}" -- \
+          nix run "$(resolve_tool)" -- \
             discover --rules "$RULES" --flake . --systems "$systems" --attr "$ATTR" --workers "${WORKERS:-2}"
 
   Build:


### PR DESCRIPTION
Inspired by #31, this continues the same idea, but for the tool: make it follow the workflow pin by default too

Currently, when the `discover.yaml` workflow is pinned to a tag or SHA (like `uses: stepbrobd/atelier/.github/workflows/discover.yaml@<ref>`), the tool defaults to `stepbrobd/atelier@master`

This can be worked around by pinning the same ref twice:
```
uses: stepbrobd/atelier/.github/workflows/discover.yaml@<ref>
with:
  ref: <ref>
```

However, the two pins are independent. In particular, when dependabot updates the workflow action in `uses`, the `ref` input is left unchanged and can drift from the `@<ref>` in `uses`

Callers that already set `tool`/`repository`/`ref` keep the same behavior (`tool` still takes precedence, `repository` without a `ref` still uses `master`, and `ref` without `repository` still uses `stepbrobd/atelier`)

The only behavior that changes is for callers that leave all three unset and intentionally expect a pinned workflow to keep running the tool from `master`, which seems unexpected IMO